### PR TITLE
Improve steering input method for wheel devices

### DIFF
--- a/src/specializations/vehicles/MouseSteeringVehicle.lua
+++ b/src/specializations/vehicles/MouseSteeringVehicle.lua
@@ -135,7 +135,9 @@ function MouseSteeringVehicle:updateSteering(dt)
     end
   end
 
-  Drivable.actionEventSteer(self, nil, spec.axisSide, nil, true, nil, InputDevice.CATEGORY.GAMEPAD)
+  if self.setSteeringInput ~= nil then
+    self:setSteeringInput(spec.axisSide, true, InputDevice.CATEGORY.WHEEL)
+  end
 end
 
 function MouseSteeringVehicle:isHudVisible(spec, isInside, activeCamera)


### PR DESCRIPTION
This pull request includes a change to the `MouseSteeringVehicle` specialization to improve how steering input is handled for different input devices.

Improvements to steering input handling:

* [`src/specializations/vehicles/MouseSteeringVehicle.lua`](diffhunk://#diff-4b12da1fcec45bf9966749124687cb0d96f4472ea3a9142919191ca99f566d7dL138-R140): Modified the `updateSteering` function to check if `setSteeringInput` is not nil before calling it, and to use `InputDevice.CATEGORY.WHEEL` instead of `InputDevice.CATEGORY.GAMEPAD`.