### PR TITLE
feat: persist session state; allow per-vehicle toggle when Default=ON

### DIFF
--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <modDesc descVersion="101">
   <author>aaw3k</author>
-  <version>1.2.0.0</version>
+  <version>1.2.0.1</version>
 
   <title>
     <en>Mouse Steering</en>
@@ -14,12 +14,20 @@
   <description>
     <en><![CDATA[Enables mouse-based control of vehicle steering, with fully configurable sensitivity, linearity, dead zone, smoothness, and more.
 
+Changelog Version 1.2.0.1:
+- Improved session persistence across enter/leave
+- Added per-vehicle toggle even when Default=ON (Default applies only initially)
+
 Changelog Version 1.2.0.0:
 - Migrated to FS25
 - Codebase reworked
 
 For more information or to report a bug, please visit GitHub (modnext/mouseSteering).]]></en>
     <de><![CDATA[Ermöglicht die Steuerung der Fahrzeuglenkung per Maus mit vollständig konfigurierbarer Empfindlichkeit, Linearität, Totzone, Laufruhe und mehr.
+
+Änderungsprotokoll Version 1.2.0.1:
+- Verbessert Sitzungsbeständigkeit beim Ein-/Aussteigen
+- Hinzugefügt Umschalten pro Fahrzeug auch bei Standard=AN (Standard nur initial)
 
 Änderungsprotokoll Version 1.2.0.0:
 - Migration zu FS25
@@ -28,6 +36,10 @@ For more information or to report a bug, please visit GitHub (modnext/mouseSteer
 Für weitere Informationen oder um einen Fehler zu melden, besuche bitte die GitHub (modnext/mouseSteering).]]></de>
     <fr><![CDATA[Permet de contrôler la direction du véhicule à l'aide de la souris, avec une sensibilité, une linéarité, une zone morte, une fluidité et bien plus encore entièrement configurables.
 
+Journal des modifications version 1.2.0.1:
+- Amélioré persistance en session à l’entrée/sortie
+- Ajouté bascule par véhicule même avec Défaut=ACTIF (Défaut seulement initial)
+
 Journal des modifications version 1.2.0.0:
 - Migration vers FS25
 - Révision du code
@@ -35,12 +47,20 @@ Journal des modifications version 1.2.0.0:
 Pour plus d'informations ou pour signaler un bug, veuillez visiter la page GitHub (modnext/mouseSteering).]]></fr>
     <pl><![CDATA[Umożliwia sterowanie kierownicą pojazdu za pomocą myszy, z możliwością pełnej konfiguracji czułości, liniowości, martwej strefy, płynności i nie tylko.
 
+Lista zmian w wersji 1.2.0.1:
+- Ulepszono trwałość stanu przy wsiadaniu/wysiadaniu
+- Dodano przełączanie per pojazd nawet przy Domyślnie=ON (domyślne tylko początkowo)
+
 Lista zmian w wersji 1.2.0.0:
 - Migracja do FS25
 - Przebudowa kodu
 
 Aby uzyskać więcej informacji lub zgłosić błąd, odwiedź stronę GitHub (modnext/mouseSteering).]]></pl>
     <ru><![CDATA[Обеспечивает управление рулевым управлением автомобиля с помощью мыши с полностью настраиваемой чувствительностью, линейностью, мертвой зоной, плавностью и другими параметрами.
+
+Журнал изменений версии 1.2.0.1:
+- Улучшено сохранение состояния при входе/выходе
+- Добавлено переключение для каждого ТС даже при ВКЛ по умолчанию (только изначально)
 
 Журнал изменений версии 1.2.0.0:
 - Переход на FS25


### PR DESCRIPTION
- Improved session persistence across enter/leave
- Added per-vehicle toggle even when Default=ON (Default applies only initially)
- Improved toggle action visibility with Default=ON
- Bump modDesc version to 1.2.0.1 and update changelog