### PR TITLE
fix: exclude locomotives

### DIFF
--- a/src/misc/AdditionalSpecialization.lua
+++ b/src/misc/AdditionalSpecialization.lua
@@ -20,12 +20,13 @@ function AdditionalSpecialization.finalizeTypes(self)
   -- compose the full specialization name using the mod's name
   local specialization = modName .. ".mouseSteeringVehicle"
 
-  -- add mouse steering specialization to drivable vehicles
+  -- add mouse steering specialization to drivable vehicles (except locomotives)
   for typeName, typeEntry in pairs(self:getTypes()) do
     local hasDrivable = SpecializationUtil.hasSpecialization(Drivable, typeEntry.specializations)
+    local hasLocomotive = SpecializationUtil.hasSpecialization(Locomotive, typeEntry.specializations)
     local hasMouseSteering = SpecializationUtil.hasSpecialization(specialization, typeEntry.specializations)
 
-    if hasDrivable and not hasMouseSteering then
+    if hasDrivable and not hasLocomotive and not hasMouseSteering then
       self:addSpecialization(typeName, specialization)
     end
   end

--- a/src/specializations/vehicles/MouseSteeringVehicle.lua
+++ b/src/specializations/vehicles/MouseSteeringVehicle.lua
@@ -15,6 +15,7 @@ MouseSteeringVehicle = {}
 -- @return boolean hasPrerequisite true if all prerequisite specializations are loaded
 function MouseSteeringVehicle.prerequisitesPresent(specializations)
   return SpecializationUtil.hasSpecialization(Drivable, specializations)
+      and not SpecializationUtil.hasSpecialization(Locomotive, specializations)
 end
 
 ---Initializes specialization XML schema
@@ -595,8 +596,12 @@ function MouseSteeringVehicle:calculateAxisAndSteering(spec)
 
   -- calculate normalized axis value
   local axisValue = 0
-  if self.maxRotTime ~= nil and self.minRotTime ~= nil then
-    axisValue = rotatedTime < 0 and rotatedTime / -self.maxRotTime / steeringDirection or rotatedTime / self.minRotTime / steeringDirection
+  if self.maxRotTime ~= nil and self.minRotTime ~= nil and self.maxRotTime ~= 0 and self.minRotTime ~= 0 then
+    if rotatedTime < 0 then
+      axisValue = rotatedTime / -self.maxRotTime / steeringDirection
+    else
+      axisValue = rotatedTime / self.minRotTime / steeringDirection
+    end
   end
 
   -- get settings and controller


### PR DESCRIPTION
 ## Summary
  - Exclude Locomotive specialization from mouse steering
  - Fix division by zero error in calculateAxisAndSteering
  - Simplify steering calculation logic with if-else
