### PR TITLE
Add camera follow functionality to mouse steering settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@
 
 ## Keybindings
 
-| Key        | Action              |
-| ---------- | ------------------- |
-| `Ctrl + .` | Steering Control    |
-| `Ctrl + /` | Save/Remove Vehicle |
-| `Alt`      | Rotate Camera       |
+| Key            | Action                       |
+| -------------- | ---------------------------- |
+| `Ctrl + .`     | Steering Control             |
+| `Ctrl + /`     | Save/Remove Vehicle          |
+| `Alt`          | Rotate Camera                |
+| `Ctrl + ,`     | Toggle Camera Follow         |
+| `Ctrl + Space` | Center Camera                |
 
 **Note:** You can customize these keybindings in the game's Options menu under the "Mouse Steering" section.
 

--- a/data/gui/dialogs/MouseSteeringSettingsDialog.xml
+++ b/data/gui/dialogs/MouseSteeringSettingsDialog.xml
@@ -122,6 +122,16 @@
             <Text profile="mouseSteeringSettingsTitle" text="$l10n_mouseSteering_ui_cameraRotationInside"/>
             <Text profile="mouseSteeringSettingsDescription" text="$l10n_mouseSteering_ui_cameraRotationInside_desc"/>
           </Bitmap>
+          <Bitmap profile="mouseSteeringSettingsContainer">
+            <MouseSteeringSliderOption profile="mouseSteeringSettingsSliderOption" id="cameraRotationDeadZone" onClick="onSliderChanged" minValue="0" stepSize="1" maxValue="30"/>
+            <Text profile="mouseSteeringSettingsTitle" text="$l10n_mouseSteering_ui_cameraRotationDeadZone"/>
+            <Text profile="mouseSteeringSettingsDescription" text="$l10n_mouseSteering_ui_cameraRotationDeadZone_desc"/>
+          </Bitmap>
+          <Bitmap profile="mouseSteeringSettingsContainerNumLines2">
+            <BinaryOption profile="mouseSteeringSettingsBinaryOption" id="cameraRotationCenterVertical" onClick="onToggleChanged"/>
+            <Text profile="mouseSteeringSettingsTitleNumLines2" text="$l10n_mouseSteering_ui_cameraRotationCenterVertical"/>
+            <Text profile="mouseSteeringSettingsDescriptionNumLines2" text="$l10n_mouseSteering_ui_cameraRotationCenterVertical_desc"/>
+          </Bitmap>
           <Text profile="mouseSteeringSettingsSectionHeader" name="sectionHeader" text="$l10n_mouseSteering_ui_indicator"/>
           <Bitmap profile="mouseSteeringSettingsContainer">
             <MouseSteeringMultiTextOption profile="mouseSteeringSettingsMultiTextOption" id="indicatorMode" onClick="onMultiChanged" texts="$l10n_mouseSteering_ui_both|$l10n_mouseSteering_ui_inside|$l10n_mouseSteering_ui_outside|$l10n_ui_off"/>

--- a/data/settings.xml
+++ b/data/settings.xml
@@ -13,6 +13,8 @@
 
   <!-- Camera -->
   <cameraRotationInside>off</cameraRotationInside>  <!-- Options: off, subtle, normal, strong, max -->
+  <cameraRotationDeadZone>0.000000</cameraRotationDeadZone>
+  <cameraRotationCenterVertical>false</cameraRotationCenterVertical>
 
   <!-- HUD Indicator -->
   <indicatorMode>both</indicatorMode>  <!-- Options: both, inside, outside, off -->

--- a/l10n/l10n_br.xml
+++ b/l10n/l10n_br.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Controle de direção"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Salvar/Remover veículo"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Girar câmera"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Alternar Câmera Segue"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centralizar câmera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interface"/>
     <e k="mouseSteering_ui_camera" v="Câmera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Câmera Segue a Direção"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zona Morta da Câmera Segue"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centralizar Rotação Vertical"/>
     <e k="mouseSteering_ui_off" v="Desligado"/>
     <e k="mouseSteering_ui_subtle" v="Sutil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="A câmera gira para seguir a direção do volante dentro da cabine."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Limite do ângulo de direção (em graus) abaixo do qual a câmera não girará."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Quando ativado, a centralização da câmera redefine a rotação horizontal e vertical. Quando desativado, apenas a rotação horizontal é centralizada."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Seleciona como o indicador de direção é mostrado no HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Mostra o ângulo de direção atual como texto na tela no indicador."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Mostra o indicador ao olhar para trás na visão interna."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Número máximo de veículos atingido"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Câmera Segue Direção está desativada. Ative nas configurações"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Veículo adicionado com sucesso"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Veículo removido com sucesso"/>
   </elements>

--- a/l10n/l10n_cs.xml
+++ b/l10n/l10n_cs.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="方向控制"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="保存/移除车辆"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="旋转摄像机"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="切换摄像机跟随"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="居中相机"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="界面"/>
     <e k="mouseSteering_ui_camera" v="摄像机"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="摄像机跟随转向"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="摄像机跟随死区"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="居中垂直旋转"/>
     <e k="mouseSteering_ui_off" v="关闭"/>
     <e k="mouseSteering_ui_subtle" v="轻微"/>
     <e k="mouseSteering_ui_normal" v="正常"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="摄像机在驾驶舱内旋转以跟随方向盘转向。"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="转向角度阈值（以度为单位），低于该值摄像机将不会旋转。"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="启用时，摄像机居中会重置水平和垂直旋转。禁用时，仅重置水平旋转。"/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="选择在HUD上如何显示转向指示器。"/>
     <e k="mouseSteering_ui_indicatorText_desc" v="在指示器上以屏幕文本显示当前转向角度。"/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="在内视角回头时显示指示器。"/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="已达到车辆数量上限"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="摄像机跟随转向已禁用。请在设置中启用"/>
     <e k="mouseSteering_notification_vehicleAdded" v="车辆添加成功"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="车辆移除成功"/>
   </elements>

--- a/l10n/l10n_ct.xml
+++ b/l10n/l10n_ct.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="方向控制"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="儲存/移除載具"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="旋轉鏡頭"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="切換攝影機跟隨"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="置中攝影機"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="介面"/>
     <e k="mouseSteering_ui_camera" v="攝影機"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="攝影機跟隨轉向"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="攝影機跟隨死區"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="置中垂直旋轉"/>
     <e k="mouseSteering_ui_off" v="關閉"/>
     <e k="mouseSteering_ui_subtle" v="輕微"/>
     <e k="mouseSteering_ui_normal" v="正常"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="攝影機在駕駛艙內旋轉以跟隨方向盤轉向。"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="轉向角度閾值（以度為單位），低於該值攝影機將不會旋轉。"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="啟用時，攝影機置中會重設水平和垂直旋轉。停用時，僅重設水平旋轉。"/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="選擇方向指示器在HUD上的顯示方式。"/>
     <e k="mouseSteering_ui_indicatorText_desc" v="在指示器中以螢幕文字顯示當前轉向角度。"/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="於內視角回頭時顯示指示器。"/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="達到車輛上限"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="攝影機跟隨轉向已停用。請在設定中啟用"/>
     <e k="mouseSteering_notification_vehicleAdded" v="車輛新增成功"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="車輛移除成功"/>
   </elements>

--- a/l10n/l10n_cz.xml
+++ b/l10n/l10n_cz.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Ovládání řízení"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Uložit/odstranit vozidlo"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Otočit kameru"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Přepnout sledování kamerou"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Vycentrovat kameru"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Rozhraní"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera sleduje řízení"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Mrtvá zóna sledování kamery"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Vycentrovat vertikální rotaci"/>
     <e k="mouseSteering_ui_off" v="Vypnuto"/>
     <e k="mouseSteering_ui_subtle" v="Jemné"/>
     <e k="mouseSteering_ui_normal" v="Normální"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kamera se otáčí, aby sledovala řízení volantu uvnitř kabiny."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Prahová hodnota úhlu řízení (ve stupních), pod kterou se kamera neotočí."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Pokud je zapnuto, centrování kamery resetuje horizontální i vertikální rotaci. Pokud je vypnuto, resetuje se pouze horizontální rotace."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Vybere, jak se indikátor řízení zobrazí na HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Zobrazí aktuální úhel řízení jako text na obrazovce v indikátoru."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Zobrazí indikátor při pohledu zpět ve vnitřním zobrazení."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Dosáhlo se maximálního počtu vozidel"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Sledování řízení kamerou je vypnuto. Zapněte ji v nastavení"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Vozidlo bylo úspěšně přidáno"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Vozidlo bylo úspěšně odstraněno"/>
   </elements>

--- a/l10n/l10n_da.xml
+++ b/l10n/l10n_da.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Styring"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Gem/fjern køretøj"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Drej kamera"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Slå kameraet der følger til/fra"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centrer kamera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interface"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera følger styring"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Kameraets døde zone"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centrer vertikal rotation"/>
     <e k="mouseSteering_ui_off" v="Fra"/>
     <e k="mouseSteering_ui_subtle" v="Svag"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kameraet roterer for at følge rattet inden i kabinen."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Styrevinkeltærskel (i grader), under hvilken kameraet ikke vil rotere."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Når det er aktiveret, nulstiller kameracentralisering både horisontal og vertikal rotation. Når det er deaktiveret, centraliseres kun horisontal rotation."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Vælger, hvordan styreindikatoren vises på HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Viser den aktuelle styrevinkel som tekst på skærmen i indikatoren."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Viser indikatoren, når man kigger bagud i indvendig visning."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Maksimalt antal køretøjer nået"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Kamera der følger styring er deaktiveret. Aktivér det i indstillinger"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Køretøj tilføjet"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Køretøj fjernet"/>
   </elements>

--- a/l10n/l10n_de.xml
+++ b/l10n/l10n_de.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Lenksteuerung"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Fahrzeug speichern/entfernen"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Kamera drehen"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Kamera Folgt Umschalten"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Kamera zentrieren"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Anzeige"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera folgt Lenkung"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Kamera Folgt Totzone"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Vertikale Rotation Zentrieren"/>
     <e k="mouseSteering_ui_off" v="Aus"/>
     <e k="mouseSteering_ui_subtle" v="Subtil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kamera dreht sich beim Lenken in der Kabine mit."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Lenkwinkelschwelle (in Grad), unter der sich die Kamera nicht dreht."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Wenn aktiviert, setzt die Kamerazentrierung sowohl die horizontale als auch die vertikale Rotation zurück. Wenn deaktiviert, wird nur die horizontale Rotation zurückgesetzt."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Wählt aus, wie die Lenkungsanzeige auf dem HUD angezeigt wird."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Zeigt den aktuellen Lenkwinkel als Text auf dem Bildschirm in der Anzeige an."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Zeigt die Anzeige beim Blick zurück in die Innenansicht an."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Maximale Anzahl an Fahrzeugen erreicht"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Kamera folgt Lenkung ist deaktiviert. Aktivieren Sie es in den Einstellungen"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Fahrzeug erfolgreich hinzugefügt"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Fahrzeug erfolgreich entfernt"/>
   </elements>

--- a/l10n/l10n_ea.xml
+++ b/l10n/l10n_ea.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Control de dirección"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Guardar/Eliminar vehículo"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Rotar cámara"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Alternar la cámara que sigue"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centrar cámara"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interfaz"/>
     <e k="mouseSteering_ui_camera" v="Cámara"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Cámara Sigue la Dirección"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zona muerta de la cámara"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centrar rotación vertical"/>
     <e k="mouseSteering_ui_off" v="Desactivado"/>
     <e k="mouseSteering_ui_subtle" v="Sutil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="La cámara gira para seguir la dirección del volante dentro de la cabina."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Umbral de ángulo de dirección (en grados) por debajo del cual la cámara no girará."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Cuando está activado, el centrado de la cámara restablece la rotación tanto horizontal como vertical. Cuando está desactivado, solo se centra la rotación horizontal."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Selecciona cómo se muestra el indicador de dirección en el HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Muestra el ángulo actual de dirección como texto en pantalla en el indicador."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Muestra el indicador al mirar hacia atrás en vista interior."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Se alcanzó el número máximo de vehículos"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="La cámara que sigue la dirección está deshabilitada. Habilitarla en la configuración"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Vehículo agregado exitosamente"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Vehículo eliminado exitosamente"/>
   </elements>

--- a/l10n/l10n_en.xml
+++ b/l10n/l10n_en.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Steering Control"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Save/Remove Vehicle"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Rotate Camera"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Toggle Camera Follow"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Center Camera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="HUD"/>
     <e k="mouseSteering_ui_camera" v="Camera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Camera Follow Steering"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Camera Follow Dead Zone"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Center Vertical Rotation"/>
     <e k="mouseSteering_ui_off" v="Off"/>
     <e k="mouseSteering_ui_subtle" v="Subtle"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Camera rotates to follow wheel steering inside the cabin."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Steering angle threshold (in degrees) below which the camera will not rotate."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="When enabled, camera centering resets both horizontal and vertical rotation. When disabled, only horizontal rotation is centered."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Selects how the steering indicator is shown on the HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Shows the current steering angle as on-screen text in the indicator."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Shows the indicator when looking back in inside view."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Maximum number of vehicles reached"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Camera Follow Steering is disabled. Enable it in settings"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Vehicle added successfully"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Vehicle removed successfully"/>
   </elements>

--- a/l10n/l10n_es.xml
+++ b/l10n/l10n_es.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Control de dirección"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Guardar/Eliminar vehículo"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Girar cámara"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Alternar cámara que sigue"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centrar cámara"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interfaz"/>
     <e k="mouseSteering_ui_camera" v="Cámara"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Cámara Sigue la Dirección"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zona muerta de la cámara"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centrar rotación vertical"/>
     <e k="mouseSteering_ui_off" v="Desactivado"/>
     <e k="mouseSteering_ui_subtle" v="Sutil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="La cámara gira para seguir la dirección del volante dentro de la cabina."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Umbral de ángulo de dirección (en grados) por debajo del cual la cámara no girará."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Cuando está activado, el centrado de la cámara restablece la rotación tanto horizontal como vertical. Cuando está desactivado, solo se centra la rotación horizontal."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Selecciona cómo se muestra el indicador de dirección en el HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Muestra el ángulo de dirección actual como texto en pantalla en el indicador."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Muestra el indicador al mirar hacia atrás en la vista interior."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Se ha alcanzado el número máximo de vehículos"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="La cámara que sigue la dirección está deshabilitada. Habilítala en la configuración"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Vehículo añadido correctamente"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Vehículo eliminado correctamente"/>
   </elements>

--- a/l10n/l10n_fc.xml
+++ b/l10n/l10n_fc.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Contrôle de la direction"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Sauvegarder/Supprimer le véhicule"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Tourner la caméra"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Activer/désactiver le suivi par la caméra"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centrer la caméra"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="ATH"/>
     <e k="mouseSteering_ui_camera" v="Caméra"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Caméra Suit la Direction"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zone morte de la caméra"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centrer la rotation verticale"/>
     <e k="mouseSteering_ui_off" v="Désactivé"/>
     <e k="mouseSteering_ui_subtle" v="Subtil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="La caméra tourne pour suivre la direction du volant dans la cabine."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Seuil d'angle de direction (en degrés) en dessous duquel la caméra ne pivotera pas."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Lorsqu'activée, la mise au centre de la caméra réinitialise la rotation horizontale et verticale. Lorsque désactivée, seule la rotation horizontale est centrée."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Choisit comment l'indicateur de direction s'affiche dans le HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Affiche l'angle de direction actuel en texte à l'écran dans l'indicateur."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Affiche l'indicateur quand vous regardez en arrière en vue intérieure."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Nombre Max de Véhicules Atteint"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Le suivi de la direction par la caméra est désactivé. Activez-le dans les paramètres"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Véhicule Ajouté avec Succès"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Véhicule Supprimé avec Succès"/>
   </elements>

--- a/l10n/l10n_fi.xml
+++ b/l10n/l10n_fi.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Ohjaus"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Tallenna/poista ajoneuvo"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Kierrä kameraa"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Vaihda kameran seuraavaksi"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Keskitä kamera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Käyttöliittymä"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera seuraa ohjausta"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Kameran kuollut alue"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Keskitä pystysuora kierto"/>
     <e k="mouseSteering_ui_off" v="Pois"/>
     <e k="mouseSteering_ui_subtle" v="Hienovarainen"/>
     <e k="mouseSteering_ui_normal" v="Normaali"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kamera kääntyy seuraamaan rattia ohjaamon sisällä."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Ohjauskulman kynnysarvo (asteissa), jonka alapuolella kamera ei kierny."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Kun käytössä, kameran keskitys nollaa sekä vaakasuoran että pystysuoran kiertymisen. Kun pois käytöstä, vain vaakasuora kiertyminen keskitetään."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Valitsee, miten ohjausindikaattori näytetään HUD:ssa."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Näyttää nykyisen ohjauskulman tekstinä indikaattorissa."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Näyttää indikaattorin, kun katsotaan taaksepäin sisäkuvassa."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Ajoneuvojen enimmäismäärä saavutettu"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Kamera seuraava ohjaus on poistettu käytöstä. Ota se käyttöön asetuksissa"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Ajoneuvo lisätty onnistuneesti"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Ajoneuvo poistettu onnistuneesti"/>
   </elements>

--- a/l10n/l10n_fr.xml
+++ b/l10n/l10n_fr.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Contrôle de la direction"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Enregistrer/Supprimer le véhicule"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Faire pivoter la caméra"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Activer/désactiver le suivi par la caméra"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centrer la caméra"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="ATH"/>
     <e k="mouseSteering_ui_camera" v="Caméra"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Caméra Suit la Direction"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zone morte de la caméra"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centrer la rotation verticale"/>
     <e k="mouseSteering_ui_off" v="Désactivé"/>
     <e k="mouseSteering_ui_subtle" v="Subtil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="La caméra tourne pour suivre la direction du volant à l'intérieur de la cabine."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Seuil d'angle de direction (en degrés) en dessous duquel la caméra ne pivotera pas."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Lorsqu'activée, la mise au centre de la caméra réinitialise la rotation horizontale et verticale. Lorsque désactivée, seule la rotation horizontale est centrée."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Sélectionne la manière dont l'indicateur de direction est affiché sur le HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Affiche l'angle de direction actuel sous forme de texte à l'écran dans l'indicateur."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Affiche l'indicateur lorsque vous regardez en arrière dans la vue intérieure."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Nombre Maximum de Véhicules Atteint"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Le suivi de la direction par la caméra est désactivé. Activez-le dans les paramètres"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Véhicule Ajouté avec Succès"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Véhicule Supprimé avec Succès"/>
   </elements>

--- a/l10n/l10n_hu.xml
+++ b/l10n/l10n_hu.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Kormányzás vezérlése"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Jármű mentése/eltávolítása"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Kamera forgatása"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Kamera követésének váltása"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Kamera középre"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Felület"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera követi a kormányzást"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Kamera holtzónája"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Függőleges forgatás középre"/>
     <e k="mouseSteering_ui_off" v="Ki"/>
     <e k="mouseSteering_ui_subtle" v="Finom"/>
     <e k="mouseSteering_ui_normal" v="Normál"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="A kamera forog, hogy kövesse a kormánykerék mozgását a kabinon belül."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Kormányzási szög küszöbérték (fokban), amely alatt a kamera nem forog."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Ha engedélyezve van, a kamera középre helyezése mind a vízszintes, mind a függőleges forgatást visszaállítja. Ha letiltva van, csak a vízszintes forgatás kerül középre."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Kiválasztja, hogyan jelenik meg a kormányzási jelző a HUD-on."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Megjeleníti az aktuális kormányzási szöget szövegként a jelzőben."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Megjeleníti a jelzőt, ha hátrafelé nézünk a belső nézetben."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Elérte a járművek maximális számát"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="A kamera kormányzás követése letiltva van. Engedélyezze a beállításokban"/>
     <e k="mouseSteering_notification_vehicleAdded" v="A jármű hozzáadása sikeres volt"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="A jármű eltávolítása sikeres volt"/>
   </elements>

--- a/l10n/l10n_id.xml
+++ b/l10n/l10n_id.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Kontrol Kemudi"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Simpan/Hapus Kendaraan"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Putar Kamera"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Aktifkan/Nonaktifkan Kamera Ikuti"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Pusatkan kamera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Antarmuka"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera Mengikuti Kemudi"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zona Mati Kamera"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Pusatkan Rotasi Vertikal"/>
     <e k="mouseSteering_ui_off" v="Mati"/>
     <e k="mouseSteering_ui_subtle" v="Halus"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kamera berputar mengikuti kemudi setir di dalam kabin."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Ambang batas sudut kemudi (dalam derajat) di mana kamera tidak akan berputar."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Saat diaktifkan, pemusatan kamera mengatur ulang rotasi horizontal dan vertikal. Saat dinonaktifkan, hanya rotasi horizontal yang dimusatkan."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Memilih cara indikator kemudi ditampilkan di HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Menampilkan sudut kemudi saat ini sebagai teks di layar dalam indikator."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Menampilkan indikator saat melihat ke belakang dalam tampilan dalam."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Jumlah maksimum kendaraan tercapai"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Kamera Ikuti Kemudi dinonaktifkan. Aktifkan di pengaturan"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Kendaraan ditambahkan dengan sukses"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Kendaraan dihapus dengan sukses"/>
   </elements>

--- a/l10n/l10n_it.xml
+++ b/l10n/l10n_it.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Controllo sterzo"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Salva/Rimuovi veicolo"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Ruota telecamera"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Attiva/disattiva fotocamera che segue"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centra telecamera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interfaccia"/>
     <e k="mouseSteering_ui_camera" v="Fotocamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Fotocamera Segue la Direzione"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zona morta della fotocamera"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centra rotazione verticale"/>
     <e k="mouseSteering_ui_off" v="Disattivato"/>
     <e k="mouseSteering_ui_subtle" v="Sottile"/>
     <e k="mouseSteering_ui_normal" v="Normale"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="La fotocamera ruota per seguire lo sterzo all'interno della cabina."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Soglia dell'angolo di sterzata (in gradi) al di sotto della quale la fotocamera non ruota."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Se abilitato, il centraggio della fotocamera ripristina sia la rotazione orizzontale che quella verticale. Se disabilitato, viene centrata solo la rotazione orizzontale."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Seleziona la modalità di visualizzazione dell'indicatore di sterzata sull'HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Mostra l'angolo di sterzata corrente come testo sullo schermo nell'indicatore."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Mostra l'indicatore quando si guarda indietro nella vista interna."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Numero massimo di veicoli raggiunto"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Fotocamera che segue la direzione è disabilitata. Abilitala nelle impostazioni"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Veicolo aggiunto con successo"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Veicolo rimosso con successo"/>
   </elements>

--- a/l10n/l10n_jp.xml
+++ b/l10n/l10n_jp.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="ステアリング制御"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="車両の保存/削除"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="カメラの回転"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="カメラ追従の切り替え"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="カメラを中央に"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="インターフェース"/>
     <e k="mouseSteering_ui_camera" v="カメラ"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="カメラがステアリングを追従"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="カメラ追従デッドゾーン"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="垂直回転を中央に"/>
     <e k="mouseSteering_ui_off" v="オフ"/>
     <e k="mouseSteering_ui_subtle" v="微弱"/>
     <e k="mouseSteering_ui_normal" v="通常"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="キャビン内でカメラがハンドル操作を追従して回転します。"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="カメラが回転しないステアリング角度のしきい値（度単位）。"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="有効の場合、カメラセンタリングは水平および垂直回転をリセットします。無効の場合は、水平回転のみがセンタリングされます。"/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="HUD上のステアリングインジケーターの表示方法を選択します。"/>
     <e k="mouseSteering_ui_indicatorText_desc" v="インジケーター内に現在のステアリング角度を画面上のテキストとして表示します。"/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="室内ビューで後ろを振り返った際にインジケーターを表示します。"/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="車両の最大数に達しました"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="カメラ追従ステアリングが無効です。設定で有効にしてください"/>
     <e k="mouseSteering_notification_vehicleAdded" v="車両が正常に追加されました"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="車両が正常に削除されました"/>
   </elements>

--- a/l10n/l10n_kr.xml
+++ b/l10n/l10n_kr.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="조향 제어"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="차량 저장/제거"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="카메라 회전"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="카메라 추적 토글"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="카메라 중앙"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="인터페이스"/>
     <e k="mouseSteering_ui_camera" v="카메라"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="카메라가 조향 추적"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="카메라 데드존"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="수직 회전 중앙"/>
     <e k="mouseSteering_ui_off" v="끔"/>
     <e k="mouseSteering_ui_subtle" v="약함"/>
     <e k="mouseSteering_ui_normal" v="보통"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="카메라가 캐빈 내부에서 핸들 조향을 따라 회전합니다."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="카메라가 회전하지 않는 조향 각도 임계값(도 단위)."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="활성화하면 카메라 센터링이 수평 및 수직 회전을 재설정합니다. 비활성화하면 수평 회전만 중앙에 배치됩니다."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="HUD에 스티어링 표시기가 표시되는 방식을 선택합니다."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="표시기에 현재 스티어링 각도를 화면 텍스트로 표시합니다."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="내부 시점으로 뒤를 돌아볼 때 표시기를 표시합니다."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="최대 차량 수에 도달했습니다"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="카메라 조향 추적이 비활성화되었습니다. 설정에서 활성화하세요"/>
     <e k="mouseSteering_notification_vehicleAdded" v="차량이 성공적으로 추가되었습니다"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="차량이 성공적으로 제거되었습니다"/>
   </elements>

--- a/l10n/l10n_meta.xml
+++ b/l10n/l10n_meta.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v=""/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v=""/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v=""/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v=""/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v=""/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v=""/>
     <e k="mouseSteering_ui_camera" v=""/>
     <e k="mouseSteering_ui_cameraRotationInside" v=""/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v=""/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v=""/>
     <e k="mouseSteering_ui_off" v=""/>
     <e k="mouseSteering_ui_subtle" v=""/>
     <e k="mouseSteering_ui_normal" v=""/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v=""/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v=""/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v=""/>
     <e k="mouseSteering_ui_indicatorMode_desc" v=""/>
     <e k="mouseSteering_ui_indicatorText_desc" v=""/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v=""/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v=""/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v=""/>
     <e k="mouseSteering_notification_vehicleAdded" v=""/>
     <e k="mouseSteering_notification_vehicleRemoved" v=""/>
   </elements>

--- a/l10n/l10n_nl.xml
+++ b/l10n/l10n_nl.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Stuurbesturing"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Voertuig opslaan/verwijderen"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Camera draaien"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Camera volgt aan/uit"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Camera centreren"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interface"/>
     <e k="mouseSteering_ui_camera" v="Camera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Camera Volgt Besturing"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Dode zone camera"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Verticale rotatie centreren"/>
     <e k="mouseSteering_ui_off" v="Uit"/>
     <e k="mouseSteering_ui_subtle" v="Subtiel"/>
     <e k="mouseSteering_ui_normal" v="Normaal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Camera draait om de stuurbeweging te volgen in de cabine."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Drempelwaarde voor stuurhoek (in graden) waaronder de camera niet draait."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Wanneer ingeschakeld, zet camera centreren zowel horizontale als verticale rotatie terug. Wanneer uitgeschakeld, wordt alleen horizontale rotatie gecentreerd."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Selecteert hoe de stuurindicator wordt weergegeven op de HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Toont de huidige stuurhoek als tekst op het scherm in de indicator."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Toont de indicator bij achteruitkijken in het binnenzicht."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Maximaal aantal voertuigen bereikt"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Camera volgt besturing is uitgeschakeld. Schakel het in de instellingen in"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Voertuig succesvol toegevoegd"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Voertuig succesvol verwijderd"/>
   </elements>

--- a/l10n/l10n_no.xml
+++ b/l10n/l10n_no.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Styring"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Lagre/fjern kjøretøy"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Roter kamera"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Slå på/av kamera som følger"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Sentrer kamera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Grensesnitt"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera følger styring"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Kameraets dødssone"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Sentrer vertikal rotasjon"/>
     <e k="mouseSteering_ui_off" v="Av"/>
     <e k="mouseSteering_ui_subtle" v="Subtil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kameraet roterer for å følge rattbevegelsen inne i førerhuset."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Styrevinkelterskel (i grader) under som kameraet ikke roterer."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Når aktivert, tilbakestiller kamerasentrering både horisontal og vertikal rotasjon. Når deaktivert, er bare horisontal rotasjon sentrert."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Velger hvordan styreindikatoren vises på HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Viser gjeldende styrevinkel som tekst på skjermen i indikatoren."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Viser indikatoren når du ser bakover i innvendig visning."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Maksimalt antall kjøretøy nådd"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Kamera som følger styring er deaktivert. Aktiver det i innstillinger"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Kjøretøy lagt til"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Kjøretøy fjernet"/>
   </elements>

--- a/l10n/l10n_pl.xml
+++ b/l10n/l10n_pl.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Sterowanie Kierownicą"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Zapisz/Usuń Pojazd"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Obróć Kamerę"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Przełącz Śledzenie Kamery"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Wycentruj Kamerę"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interfejs"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera Śledzi Skręt"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Martwa Strefa Śledzenia Kamery"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Wycentruj Obrót Pionowy"/>
     <e k="mouseSteering_ui_off" v="Wyłączona"/>
     <e k="mouseSteering_ui_subtle" v="Subtelna"/>
     <e k="mouseSteering_ui_normal" v="Normalna"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kamera obraca się zgodnie ze skrętem kół wewnątrz kabiny."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Próg kąta skrętu (w stopniach), poniżej którego kamera nie będzie się obracać."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Po włączeniu centrowanie kamery resetuje zarówno obrót poziomy, jak i pionowy. Po wyłączeniu resetowany jest tylko obrót poziomy."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Wybiera sposób wyświetlania wskaźnika skrętu na HUDzie."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Pokazuje aktualny kąt skrętu jako tekst na ekranie we wskaźniku."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Pokazuje wskaźnik podczas patrzenia do tyłu w widoku wewnętrznym."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Osiągnięto maksymalną liczbę pojazdów"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Śledzenie Skrętu przez Kamerę jest wyłączone. Włącz w ustawieniach"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Pojazd dodany pomyślnie"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Pojazd usunięty pomyślnie"/>
   </elements>

--- a/l10n/l10n_pt.xml
+++ b/l10n/l10n_pt.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Controlo de direção"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Guardar/Remover veículo"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Rodar câmara"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Alternar câmara que segue"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centrar câmara"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interface"/>
     <e k="mouseSteering_ui_camera" v="Câmara"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Câmara Segue a Direção"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zona morta da câmara"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centrar rotação vertical"/>
     <e k="mouseSteering_ui_off" v="Desligado"/>
     <e k="mouseSteering_ui_subtle" v="Subtil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="A câmara roda para seguir a direção do volante dentro da cabine."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Limiar de ângulo de direção (em graus) abaixo do qual a câmara não rodará."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Quando ativado, o centramento da câmara repõe a rotação horizontal e vertical. Quando desativado, apenas a rotação horizontal é centrada."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Seleciona como o indicador de direção é mostrado no HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Mostra o ângulo de direção atual como texto na tela no indicador."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Mostra o indicador ao olhar para trás na vista interna."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Número máximo de veículos atingido"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="A câmara que segue a direção está desativada. Ative-a nas configurações"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Veículo adicionado com sucesso"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Veículo removido com sucesso"/>
   </elements>

--- a/l10n/l10n_ro.xml
+++ b/l10n/l10n_ro.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Controlul direcției"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Salvare/Eliminare vehicul"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Rotire cameră"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Comutare urmărire cameră"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centrează camera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Interfață"/>
     <e k="mouseSteering_ui_camera" v="Cameră"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Camera Urmărește Direcția"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Zona moartă a camerei"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centrează rotația verticală"/>
     <e k="mouseSteering_ui_off" v="Dezactivat"/>
     <e k="mouseSteering_ui_subtle" v="Subtil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Camera se rotește pentru a urmări volanul în interiorul cabinei."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Prag de unghi de direcție (în grade) sub care camera nu se va roti."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Când este activat, centrarea camerei resetează rotația atât orizontală cât și verticală. Când este dezactivat, doar rotația orizontală este centrată."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Selectează modul în care indicatorul de direcție este afișat pe HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Afișează unghiul actual de direcție ca text pe ecran în indicator."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Afișează indicatorul când te uiți înapoi în vizualizarea interioară."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Numărul maxim de vehicule atins"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Urmărirea direcției de cameră este dezactivată. Activați-o în setări"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Vehicul adăugat cu succes"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Vehicul eliminat cu succes"/>
   </elements>

--- a/l10n/l10n_ru.xml
+++ b/l10n/l10n_ru.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Управление рулем"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Сохранить/удалить транспортное средство"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Поворот камеры"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Переключить камеру следующую"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Центрировать камеру"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Интерфейс"/>
     <e k="mouseSteering_ui_camera" v="Камера"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Камера Следует За Рулем"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Мертвая зона камеры"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Центрировать вертикальный поворот"/>
     <e k="mouseSteering_ui_off" v="Выкл"/>
     <e k="mouseSteering_ui_subtle" v="Легко"/>
     <e k="mouseSteering_ui_normal" v="Обычно"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Камера поворачивается вслед за поворотом руля внутри кабины."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Пороговое значение угла поворота (в градусах), ниже которого камера не будет вращаться."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Если включено, центрирование камеры восстанавливает как горизонтальное, так и вертикальное вращение. Если отключено, центрируется только горизонтальное вращение."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Выбирает способ отображения индикатора рулевого управления на HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Отображает текущий угол поворота руля в виде текста на экране в индикаторе."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Отображает индикатор при взгляде назад в режиме внутреннего обзора."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Достигнуто максимальное количество транспортных средств"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Камера, следующая за рулем, отключена. Включите её в настройках"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Транспортное средство добавлено успешно"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Транспортное средство удалено успешно"/>
   </elements>

--- a/l10n/l10n_sv.xml
+++ b/l10n/l10n_sv.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Styrkontroll"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Spara/ta bort fordon"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Rotera kamera"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Slå på/av kamera följer"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Centrera kamera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Gränssnitt"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera följer styrning"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Kameradödzon"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Centrera vertikal rotation"/>
     <e k="mouseSteering_ui_off" v="Av"/>
     <e k="mouseSteering_ui_subtle" v="Subtil"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kameran roterar för att följa ratten inne i hytten."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Styrvinkeltröskel (i grader) under vilken kameran inte roterar."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="När den är aktiverad återställer kameracentrering både horisontell och vertikal rotation. När den är inaktiverad centreras endast horisontell rotation."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Väljer hur styrindikatorn visas på HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Visar aktuell styrvinkel som text på skärmen i indikatorn."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Visar indikatorn när du tittar bakåt i invändig vy."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Maximalt antal fordon uppnått"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Kamera följer styrning är inaktiverad. Aktivera den i inställningar"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Fordon tillagt"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Fordon borttaget"/>
   </elements>

--- a/l10n/l10n_tr.xml
+++ b/l10n/l10n_tr.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Direksiyon Kontrolü"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Aracı Kaydet/Sil"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Kamerayı Döndür"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Kamera Takipini Aç/Kapat"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Kamerayı ortala"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Arayüz"/>
     <e k="mouseSteering_ui_camera" v="Kamera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Kamera Direksiyonu Takip Eder"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Kamera Ölü Bölgesi"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Dikey Rotasyonu Ortala"/>
     <e k="mouseSteering_ui_off" v="Kapalı"/>
     <e k="mouseSteering_ui_subtle" v="Hafif"/>
     <e k="mouseSteering_ui_normal" v="Normal"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Kamera, kabin içindeki direksiyon hareketini takip etmek için döner."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Kameranın dönmeyeceği direksiyon açısı eşiği (derece cinsinden)."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Etkinleştirildiğinde, kamera ortalama işlemi hem yatay hem de dikey rotasyonu sıfırlar. Devre dışı bırakıldığında, yalnızca yatay rotasyon ortalanır."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Direksiyon göstergesinin HUD'da nasıl gösterileceğini seçer."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Mevcut direksiyon açısını göstergede ekran metni olarak gösterir."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="İç görüşte geriye bakarken göstergeyi gösterir."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Maksimum araç sayısına ulaşıldı"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Kamera Direksiyon Takibi devre dışı bırakıldı. Ayarlardan etkinleştirin"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Araç başarıyla eklendi"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Araç başarıyla kaldırıldı"/>
   </elements>

--- a/l10n/l10n_uk.xml
+++ b/l10n/l10n_uk.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Управління кермом"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Зберегти/Видалити транспортний засіб"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Повернути камеру"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Переключити камеру слідування"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Центрувати камеру"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Інтерфейс"/>
     <e k="mouseSteering_ui_camera" v="Камера"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Камера слідує за кермом"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Мертва зона камери"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Центрувати вертикальне обертання"/>
     <e k="mouseSteering_ui_off" v="Вимкнено"/>
     <e k="mouseSteering_ui_subtle" v="Ледь помітно"/>
     <e k="mouseSteering_ui_normal" v="Нормально"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Камера обертається, щоб слідувати за поворотом керма всередині кабіни."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Поріг кута керування (в градусах), нижче якого камера не обертатиметься."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Коли ввімкнено, центрування камери скидає як горизонтальне, так і вертикальне обертання. Коли вимкнено, центрується лише горизонтальне обертання."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Вибирає спосіб відображення індикатора керування на HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Показує поточний кут повороту керма у вигляді тексту на екрані в індикаторі."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Показує індикатор при погляді назад у внутрішньому вигляді."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Досягнуто максимальної кількості транспортних засобів"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Камера слідування за кермом вимкнена. Ввімкніть її в налаштуваннях"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Транспортний засіб додано успішно"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Транспортний засіб видалено успішно"/>
   </elements>

--- a/l10n/l10n_vi.xml
+++ b/l10n/l10n_vi.xml
@@ -5,6 +5,7 @@
     <e k="input_TOGGLE_MOUSE_STEERING_CONTROL" v="Điều khiển lái"/>
     <e k="input_TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" v="Lưu/Xóa phương tiện"/>
     <e k="input_TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" v="Xoay camera"/>
+    <e k="input_TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" v="Chuyển đổi theo dõi bằng camera"/>
     <e k="input_TOGGLE_MOUSE_STEERING_CENTER_CAMERA" v="Căn giữa camera"/>
 
     <!-- Actions -->
@@ -61,6 +62,8 @@
     <e k="mouseSteering_ui_hud" v="Giao diện"/>
     <e k="mouseSteering_ui_camera" v="Camera"/>
     <e k="mouseSteering_ui_cameraRotationInside" v="Camera Theo Hướng Lái"/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone" v="Vùng chết camera"/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical" v="Căn giữa xoay dọc"/>
     <e k="mouseSteering_ui_off" v="Tắt"/>
     <e k="mouseSteering_ui_subtle" v="Nhẹ"/>
     <e k="mouseSteering_ui_normal" v="Bình thường"/>
@@ -76,6 +79,8 @@
 
     <!-- Descriptions: HUD Settings -->
     <e k="mouseSteering_ui_cameraRotationInside_desc" v="Camera xoay theo hướng lái của vô lăng bên trong cabin."/>
+    <e k="mouseSteering_ui_cameraRotationDeadZone_desc" v="Ngưỡng góc lái (tính bằng độ) dưới đó camera sẽ không xoay."/>
+    <e k="mouseSteering_ui_cameraRotationCenterVertical_desc" v="Khi bật, căn giữa camera đặt lại cả xoay ngang và dọc. Khi tắt, chỉ xoay ngang được căn giữa."/>
     <e k="mouseSteering_ui_indicatorMode_desc" v="Chọn cách hiển thị chỉ báo lái trên HUD."/>
     <e k="mouseSteering_ui_indicatorText_desc" v="Hiển thị góc lái hiện tại dưới dạng văn bản trên màn hình trong chỉ báo."/>
     <e k="mouseSteering_ui_indicatorLookBackInside_desc" v="Hiển thị chỉ báo khi nhìn lại trong chế độ xem bên trong."/>
@@ -117,6 +122,7 @@
 
     <!-- Notifications & Warnings -->
     <e k="mouseSteering_warning_vehicleLimit" v="Đã đạt số lượng xe tối đa"/>
+    <e k="mouseSteering_warning_cameraFollowDisabled" v="Theo dõi hướng lái bằng camera bị vô hiệu hóa. Bật nó trong cài đặt"/>
     <e k="mouseSteering_notification_vehicleAdded" v="Xe đã được thêm thành công"/>
     <e k="mouseSteering_notification_vehicleRemoved" v="Xe đã được xóa thành công"/>
   </elements>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -126,6 +126,7 @@ Aby uzyskać więcej informacji lub zgłosić błąd, odwiedź stronę GitHub (m
     <action name="TOGGLE_MOUSE_STEERING_CONTROL" category="VEHICLE" axisType="HALF" displayCategory="VEHICLE_MOUSE_STEERING"/>
     <action name="TOGGLE_MOUSE_STEERING_SAVE_DELETE_VEHICLE" category="VEHICLE" axisType="HALF" displayCategory="VEHICLE_MOUSE_STEERING"/>
     <action name="TOGGLE_MOUSE_STEERING_ROTATE_CAMERA" category="VEHICLE" axisType="HALF" displayCategory="VEHICLE_MOUSE_STEERING"/>
+    <action name="TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW" category="VEHICLE" axisType="HALF" displayCategory="VEHICLE_MOUSE_STEERING"/>
     <action name="TOGGLE_MOUSE_STEERING_CENTER_CAMERA" category="VEHICLE" axisType="HALF" displayCategory="VEHICLE_MOUSE_STEERING"/>
   </actions>
 
@@ -139,8 +140,11 @@ Aby uzyskać więcej informacji lub zgłosić błąd, odwiedź stronę GitHub (m
     <actionBinding action="TOGGLE_MOUSE_STEERING_ROTATE_CAMERA">
       <binding device="KB_MOUSE_DEFAULT" input="KEY_lalt"/>
     </actionBinding>
-    <actionBinding action="TOGGLE_MOUSE_STEERING_CENTER_CAMERA">
+    <actionBinding action="TOGGLE_MOUSE_STEERING_CAMERA_FOLLOW">
       <binding device="KB_MOUSE_DEFAULT" input="KEY_lctrl KEY_comma"/>
+    </actionBinding>
+    <actionBinding action="TOGGLE_MOUSE_STEERING_CENTER_CAMERA">
+      <binding device="KB_MOUSE_DEFAULT" input="KEY_lctrl KEY_space"/>
     </actionBinding>
   </inputBinding>
 </modDesc>

--- a/src/gui/dialogs/MouseSteeringSettingsDialog.lua
+++ b/src/gui/dialogs/MouseSteeringSettingsDialog.lua
@@ -180,6 +180,8 @@ function MouseSteeringSettingsDialog:updateUISettings()
   self.linearity:setValue(settings.linearity)
   self.smoothness:setValue(settings.smoothness)
   self.deadzone:setValue(settings.deadzone)
+  self.cameraRotationDeadZone:setValue(settings.cameraRotationDeadZone)
+  self.cameraRotationDeadZone:setFormatter(function(value) return string.format("%.0f°", value) end)
   self.steeringAssistThreshold:setValue(settings.steeringAssistThreshold)
   -- self.steeringAssistThreshold:setFormatter(function(value) return string.format("%.3f", value) end)
 
@@ -191,6 +193,7 @@ function MouseSteeringSettingsDialog:updateUISettings()
   self.autoSave:setIsChecked(settings.autoSave, true)
   self.default:setIsChecked(settings.default, true)
   self.indicatorLookBackInside:setIsChecked(settings.indicatorLookBackInside, true)
+  self.cameraRotationCenterVertical:setIsChecked(settings.cameraRotationCenterVertical, true)
 
   -- binary options
   self.indicatorText:setIsChecked(settings.indicatorText, true)
@@ -925,8 +928,8 @@ function MouseSteeringSettingsDialog:onClickOpenPageSettingsControls()
   -- locate and highlight the mouse steering controls entry
   for controlIndex, controlData in ipairs(controlsList.delegate.controlsData) do
     if controlData.name == modDisplayTitle then
-      controlsList:makeCellVisible(controlIndex, 3, true)
-      controlsList:setSelectedItem(controlIndex, 3)
+      controlsList:makeCellVisible(controlIndex, 5, true)
+      controlsList:setSelectedItem(controlIndex, 5)
 
       -- set focus to the first action button for better UX
       local targetCell = controlsList:getElementAtSectionIndex(controlIndex, 1)

--- a/src/gui/elements/MouseSteeringSliderOptionElement.lua
+++ b/src/gui/elements/MouseSteeringSliderOptionElement.lua
@@ -139,7 +139,7 @@ end
 
 ---Sets the slider value
 function MouseSteeringSliderOptionElement:setValue(value)
-  value = math.max(self.minValue, math.min(self.maxValue, value))
+  value = math.max(self.minValue, math.min(self.maxValue, value or self.minValue))
 
   -- find index
   local precision = 100000

--- a/src/misc/MouseSteeringCameraRotation.lua
+++ b/src/misc/MouseSteeringCameraRotation.lua
@@ -7,6 +7,15 @@
 
 MouseSteeringCameraRotation = {}
 
+---
+MouseSteeringCameraRotation.INTENSITY_VALUES = {
+  off = 0,
+  subtle = 0.5,
+  normal = 1,
+  strong = 1.5,
+  max = 2
+}
+
 local MouseSteeringCameraRotation_mt = Class(MouseSteeringCameraRotation)
 
 ---Creates a new instance of MouseSteeringCameraRotation
@@ -14,48 +23,104 @@ function MouseSteeringCameraRotation.new(vehicle)
   local self = setmetatable({}, MouseSteeringCameraRotation_mt)
 
   self.vehicle = vehicle
-
-  -- calculation constants
-  self.epsilon = 0.001
-  self.targetFrameTime = 16.666
-
-  -- steering factor calculation constants
-  self.steerFactorThreshold = 0.1
-  self.steerFactorMultiplier = 1.524
-  self.steerFactorExponent = 2
-  self.steerOffsetScale = 0.5
-
-  -- centering constants
-  self.centeringSmoothingFactor = 0.05
-
-  -- rotation update constants
-  self.rotationMaxDeltaPerMs = 0.002
+  self.settings = nil
+  self.isActive = false
 
   -- steering follow state
   self.rotationFactor = 0
   self.baseRotY = nil
   self.lastInsideCamera = nil
   self.lastCamIndex = nil
+  self.lastIsPaused = false
+  self.lastIsActive = false
+
+  -- per-camera position storage (key = camIndex, value = {rotYOffset, followSteering, preservePosition})
+  -- rotYOffset is relative to camera.origRotY (forward direction)
+  self.savedCameraStates = {}
 
   -- centering state
   self.centering = false
   self.centerTargetRotY = nil
+  self.centerTargetRotX = nil
   self.centeringWithSteering = false
   self.centerSteeringOffset = 0
   self.lastCenterRotY = nil
+  self.lastCenterRotX = nil
+  self.centeringRotX = false
 
   return self
 end
 
+---Sets the settings reference and active state
+-- @param settings table Settings table reference
+-- @param isActive boolean Whether camera follow steering is active
+function MouseSteeringCameraRotation:setSettings(settings, isActive)
+  self.settings = settings
+  self.isActive = isActive or false
+end
+
+---Gets intensity value from current settings
+-- @return number intensity value (0 if disabled or no settings)
+function MouseSteeringCameraRotation:getIntensity()
+  if not self.isActive or not self.settings then
+    return 0
+  end
+
+  local state = self.settings.cameraRotationInside or "off"
+  return MouseSteeringCameraRotation.INTENSITY_VALUES[state] or 0
+end
+
+---Gets deadzone value from current settings
+-- @return number deadzone in degrees
+function MouseSteeringCameraRotation:getDeadzoneDegrees()
+  if not self.settings then
+    return 0
+  end
+  return self.settings.cameraRotationDeadZone or 0
+end
+
+---Gets whether vertical centering is enabled
+-- @return boolean centerVertical
+function MouseSteeringCameraRotation:getCenterVertical()
+  if not self.settings then
+    return false
+  end
+  return self.settings.cameraRotationCenterVertical or false
+end
+
+---Checks if camera is valid and inside
+function MouseSteeringCameraRotation:isValidInsideCamera(camera)
+  return camera ~= nil and camera.isInside == true
+end
+
+---Normalizes angle difference to shortest path (-pi to pi)
+function MouseSteeringCameraRotation:normalizeAngleDiff(diff)
+  while diff > math.pi do
+    diff = diff - 2 * math.pi
+  end
+  while diff < -math.pi do
+    diff = diff + 2 * math.pi
+  end
+  return diff
+end
+
+---Calculates time-adjusted delta for smooth interpolation
+function MouseSteeringCameraRotation:calculateSmoothDelta(diff, smoothingFactor, dt)
+  local targetFrameTime = 16.666
+  return diff * smoothingFactor * (dt / targetFrameTime)
+end
+
+---Gets sign of a number (1 for positive/zero, -1 for negative)
+function MouseSteeringCameraRotation:getSign(value)
+  return value >= 0 and 1 or -1
+end
+
 ---Gets CabView rotation limits if mod is active
--- @param camera table active camera
--- @return number|nil minRot, number|nil maxRot rotation limits or nil if CabView not active
 function MouseSteeringCameraRotation:getCabViewLimits(camera)
-  if camera == nil or not camera.isInside then
+  if not self:isValidInsideCamera(camera) then
     return nil, nil
   end
 
-  -- check for CabView mod compatibility
   if not g_modIsLoaded.FS25_CabView then
     return nil, nil
   end
@@ -65,78 +130,168 @@ function MouseSteeringCameraRotation:getCabViewLimits(camera)
     return nil, nil
   end
 
-  -- get specialization data
   local cabViewSpec = vehicle["spec_FS25_CabView.cabView"]
   if cabViewSpec == nil or cabViewSpec.rotationOffset == nil then
     return nil, nil
   end
 
-  -- calculate limits based on offset
-  local minRot = -0.1 * math.pi + cabViewSpec.rotationOffset
-  local maxRot = 2.1 * math.pi + cabViewSpec.rotationOffset
+  local cabViewMinRotBase = -0.1 * math.pi
+  local cabViewMaxRotBase = 2.1 * math.pi
 
-  return minRot, maxRot
+  local offset = cabViewSpec.rotationOffset
+  return cabViewMinRotBase + offset, cabViewMaxRotBase + offset
 end
 
 ---Calculates shortest angle difference respecting CabView limits
--- @param from number current angle
--- @param to number target angle
--- @param camera table active camera
--- @return number angle difference (shortest path within limits)
 function MouseSteeringCameraRotation:getAngleDiff(from, to, camera)
-  local diff = to - from
   local minRot, maxRot = self:getCabViewLimits(camera)
 
   if minRot ~= nil and maxRot ~= nil then
-    -- CabView is active - don't allow crossing limits
+    -- CabView active - clamp target and calculate direct difference
     local targetClamped = math.clamp(to, minRot, maxRot)
     return targetClamped - from
   else
-    -- No CabView - use normal shortest path
-    while diff > math.pi do
-      diff = diff - 2 * math.pi
-    end
-    while diff < -math.pi do
-      diff = diff + 2 * math.pi
-    end
-    return diff
+    -- no CabView - use shortest path
+    return self:normalizeAngleDiff(to - from)
   end
 end
 
 ---Calculates normalized steering factor for camera rotation
--- @return number normalized steering factor (-1 to 1) with deadzone applied
-function MouseSteeringCameraRotation:calculateSteeringFactor()
+-- Returns value between -1 and 1 with deadzone applied
+function MouseSteeringCameraRotation:calculateSteeringFactor(cameraRotationDeadZoneDegrees)
   local vehicle = self.vehicle
-  local rotatedTime = vehicle.rotatedTime or 0
+  if vehicle == nil then
+    return 0
+  end
 
+  local rotatedTime = vehicle.rotatedTime or 0
   if rotatedTime == 0 then
     return 0
   end
 
-  -- calculate raw factor based on steering time
+  -- calculate raw steering factor
   local steerFactor = 0
-  if rotatedTime > 0 and vehicle.maxRotTime and vehicle.maxRotTime > 0 then
-    steerFactor = rotatedTime / vehicle.maxRotTime
-  elseif rotatedTime < 0 and vehicle.minRotTime and vehicle.minRotTime < 0 then
-    steerFactor = -(rotatedTime / vehicle.minRotTime)
+  if rotatedTime > 0 then
+    local maxRotTime = vehicle.maxRotTime
+    if maxRotTime and maxRotTime > 0 then
+      steerFactor = rotatedTime / maxRotTime
+    end
+  else
+    local minRotTime = vehicle.minRotTime
+    if minRotTime and minRotTime < 0 then
+      steerFactor = -(rotatedTime / minRotTime)
+    end
   end
 
-  -- apply deadzone threshold
+  -- steering factor calculation parameters
+  local steerFactorThreshold = 0.1
+  local steerFactorMultiplier = 1.524
+  local steerFactorExponent = 2
+  local maxSteeringAngleDegrees = 50.0
+
+  -- apply threshold deadzone
   local absSteer = math.abs(steerFactor)
-  if absSteer < self.steerFactorThreshold then
+  if absSteer < steerFactorThreshold then
     return 0
   end
 
   -- apply exponential curve for smoother response
-  local sign = steerFactor >= 0 and 1 or -1
-  return sign * self.steerFactorMultiplier * (absSteer - self.steerFactorThreshold) ^ self.steerFactorExponent
+  local steerSign = self:getSign(steerFactor)
+  local normalizedSteer = absSteer - steerFactorThreshold
+  local curvedSteer = steerSign * steerFactorMultiplier * (normalizedSteer ^ steerFactorExponent)
+
+  -- apply camera rotation dead zone
+  local cameraDeadZone = cameraRotationDeadZoneDegrees / maxSteeringAngleDegrees
+  local absCurved = math.abs(curvedSteer)
+
+  if absCurved < cameraDeadZone then
+    return 0
+  end
+
+  -- remap from [deadZone, 1.0] to [0, 1.0]
+  local remappedSteer = (absCurved - cameraDeadZone) / (1.0 - cameraDeadZone)
+  return steerSign * remappedSteer
+end
+
+---Calculates steering offset for given steering factor and intensity
+function MouseSteeringCameraRotation:calculateSteeringOffset(steeringFactor, intensity)
+  local steerOffsetScale = 0.5
+  return steeringFactor * steerOffsetScale * intensity
+end
+
+---Saves current camera state for later restoration
+function MouseSteeringCameraRotation:saveCameraState(camIndex, camera, rotYOffset, followSteering, preservePosition)
+  if camIndex == nil or camera == nil then
+    return
+  end
+
+  self.savedCameraStates[camIndex] = {
+    rotYOffset = rotYOffset,
+    followSteering = followSteering,
+    preservePosition = preservePosition or false
+  }
+end
+
+---Gets saved camera state for given index
+function MouseSteeringCameraRotation:getSavedCameraState(camIndex)
+  return self.savedCameraStates[camIndex]
+end
+
+---Calculates current rotation state as offset from forward direction
+-- Returns manualOffset (user's manual camera adjustment) and followSteering flag
+function MouseSteeringCameraRotation:calculateCurrentState(camera)
+  local epsilon = 0.001
+
+  local origRotY = camera.origRotY or 0
+  -- manualOffset is only the user's manual adjustment, not including steering follow
+  local manualOffset = (self.baseRotY or origRotY) - origRotY
+  local followSteering = math.abs(self.rotationFactor) > epsilon
+
+  return manualOffset, followSteering
+end
+
+---Finalizes centering and updates internal state
+function MouseSteeringCameraRotation:finalizeCentering(camera)
+  if self.centeringWithSteering then
+    self.baseRotY = camera.origRotY or 0
+    self.rotationFactor = self.centerSteeringOffset or 0
+  else
+    self.baseRotY = self.centerTargetRotY
+    self.rotationFactor = 0
+  end
+
+  -- save state for current camera
+  if self.lastCamIndex ~= nil then
+    local rotYOffset, followSteering = self:calculateCurrentState(camera)
+    self:saveCameraState(self.lastCamIndex, camera, rotYOffset, self.centeringWithSteering, false)
+  end
+end
+
+---Cancels active centering operation
+function MouseSteeringCameraRotation:cancelCentering()
+  self.centering = false
+  self.lastCenterRotY = nil
+  self.lastCenterRotX = nil
+  self.centeringRotX = false
 end
 
 ---Resets camera rotation tracking state
--- @param camIndex number current camera index
 function MouseSteeringCameraRotation:resetState(camIndex)
-  if self.baseRotY ~= nil and self.lastInsideCamera ~= nil then
-    self.lastInsideCamera.rotY = self.baseRotY
+  -- finalize centering if active
+  if self.centering and self.centerTargetRotY ~= nil and self.lastInsideCamera ~= nil then
+    self:finalizeCentering(self.lastInsideCamera)
+  end
+
+  -- clear centering state
+  self.centering = false
+  self.centerTargetRotY = nil
+  self.lastCenterRotY = nil
+
+  -- save state for previous camera
+  if self.lastCamIndex ~= nil and self.baseRotY ~= nil and self.lastInsideCamera ~= nil then
+    local rotYOffset, followSteering = self:calculateCurrentState(self.lastInsideCamera)
+    local preservePosition = self:isLookingBackwards(self.lastInsideCamera)
+    self:saveCameraState(self.lastCamIndex, self.lastInsideCamera, rotYOffset, followSteering, preservePosition)
   end
 
   -- reset internal state
@@ -146,55 +301,124 @@ function MouseSteeringCameraRotation:resetState(camIndex)
   self.rotationFactor = 0
 end
 
----Requests camera centering
--- @param camera table active camera
--- @param intensity number rotation intensity setting
-function MouseSteeringCameraRotation:requestCenter(camera, intensity)
+---Updates saved camera states when going to outside camera
+-- For cameras that are not looking backwards, enable steering follow
+-- so they will track steering when returning to inside
+function MouseSteeringCameraRotation:updateStatesForOutsideCamera()
+  for idx, state in pairs(self.savedCameraStates) do
+    if not state.preservePosition then
+      -- not looking backwards - enable steering follow but keep position offset
+      state.followSteering = true
+    end
+  end
+end
+
+---Requests camera centering to forward or steering-follow position (internal use)
+-- @param camera table Active camera
+-- @param intensity number Rotation intensity setting
+-- @param deadzoneDegrees number Dead zone in degrees
+-- @param centerVertical boolean Whether to also center vertical (X) rotation
+function MouseSteeringCameraRotation:requestCenter(camera, intensity, deadzoneDegrees, centerVertical)
   if camera == nil then
     return
   end
 
   local baseRotY = camera.origRotY or 0
 
-  -- set target depending on whether we should center to steering offset or original center
+  -- determine centering target based on intensity and camera type
   if intensity > 0 and camera.isInside then
-    local steeringOffset = self:calculateSteeringFactor() * self.steerOffsetScale * intensity
+    local steeringFactor = self:calculateSteeringFactor(deadzoneDegrees)
+    local steeringOffset = self:calculateSteeringOffset(steeringFactor, intensity)
+
     self.centerTargetRotY = baseRotY + steeringOffset
     self.centeringWithSteering = true
     self.centerSteeringOffset = steeringOffset
   else
     self.centerTargetRotY = baseRotY
     self.centeringWithSteering = false
+    self.centerSteeringOffset = 0
   end
 
-  -- activate centering state
+  -- setup vertical (X) rotation centering if enabled
+  self.centeringRotX = centerVertical or false
+  if self.centeringRotX then
+    self.centerTargetRotX = camera.origRotX or 0
+    self.lastCenterRotX = camera.rotX
+  else
+    self.centerTargetRotX = nil
+    self.lastCenterRotX = nil
+  end
+
   self.centering = true
   self.lastCenterRotY = camera.rotY
 end
 
----Updates camera centering (smooth transition to target)
--- @param dt number delta time in milliseconds
--- @param camera table active camera
--- @param intensity number rotation intensity setting for dynamic target updates
-function MouseSteeringCameraRotation:updateCentering(dt, camera, intensity)
+---Requests camera centering using current settings
+-- @param camera table Active camera
+function MouseSteeringCameraRotation:centerCamera(camera)
+  local intensity = self:getIntensity()
+  local deadzoneDegrees = self:getDeadzoneDegrees()
+  local centerVertical = self:getCenterVertical()
+
+  self:requestCenter(camera, intensity, deadzoneDegrees, centerVertical)
+end
+
+---Requests camera centering to original position (no steering follow)
+-- Used when camera follow steering is disabled
+-- @param camera table Active camera
+-- @param centerVertical boolean Whether to also center vertical (X) rotation
+function MouseSteeringCameraRotation:requestCenterToOrigin(camera, centerVertical)
+  if camera == nil then
+    return
+  end
+
+  self.centerTargetRotY = camera.origRotY or 0
+  self.centeringWithSteering = false
+  self.centerSteeringOffset = 0
+
+  -- setup vertical (X) rotation centering if enabled
+  self.centeringRotX = centerVertical or false
+  if self.centeringRotX then
+    self.centerTargetRotX = camera.origRotX or 0
+    self.lastCenterRotX = camera.rotX
+  else
+    self.centerTargetRotX = nil
+    self.lastCenterRotX = nil
+  end
+
+  self.centering = true
+  self.lastCenterRotY = camera.rotY
+end
+
+---Updates camera centering with smooth transition to target
+function MouseSteeringCameraRotation:updateCentering(dt, camera, intensity, cameraRotationDeadZoneDegrees)
   if not self.centering then
     return
   end
 
   -- validate state
   if camera == nil or self.centerTargetRotY == nil then
-    self.centering = false
-    self.lastCenterRotY = nil
+    self:cancelCentering()
     return
   end
 
-  -- detect manual camera movement by user
+  local epsilon = 0.001
+  local centeringSmoothingFactor = 0.05
+
+  -- detect manual camera movement by user (horizontal Y axis)
   if self.lastCenterRotY ~= nil then
-    local userMovement = camera.rotY - self.lastCenterRotY
-    if math.abs(userMovement) > self.epsilon then
-      -- user is manually moving camera, cancel centering
-      self.centering = false
-      self.lastCenterRotY = nil
+    local userMovementY = math.abs(camera.rotY - self.lastCenterRotY)
+    if userMovementY > epsilon then
+      self:cancelCentering()
+      return
+    end
+  end
+
+  -- detect manual camera movement by user (vertical X axis)
+  if self.centeringRotX and self.lastCenterRotX ~= nil then
+    local userMovementX = math.abs(camera.rotX - self.lastCenterRotX)
+    if userMovementX > epsilon then
+      self:cancelCentering()
       return
     end
   end
@@ -202,76 +426,259 @@ function MouseSteeringCameraRotation:updateCentering(dt, camera, intensity)
   -- update target dynamically if centering with steering follow
   if self.centeringWithSteering and intensity and intensity > 0 then
     local baseRotY = camera.origRotY or 0
-    local currentSteeringOffset = self:calculateSteeringFactor() * self.steerOffsetScale * intensity
-    self.centerTargetRotY = baseRotY + currentSteeringOffset
-    self.centerSteeringOffset = currentSteeringOffset
+    local steeringFactor = self:calculateSteeringFactor(cameraRotationDeadZoneDegrees)
+    local steeringOffset = self:calculateSteeringOffset(steeringFactor, intensity)
+
+    self.centerTargetRotY = baseRotY + steeringOffset
+    self.centerSteeringOffset = steeringOffset
   end
 
-  local diff = self:getAngleDiff(camera.rotY, self.centerTargetRotY, camera)
+  -- calculate differences
+  local diffY = self:getAngleDiff(camera.rotY, self.centerTargetRotY, camera)
+  local diffX = 0
+  if self.centeringRotX and self.centerTargetRotX ~= nil then
+    diffX = self.centerTargetRotX - camera.rotX
+  end
 
-  -- check if target reached
-  if math.abs(diff) < self.epsilon then
+  -- check if target reached (both axes if rotX centering is enabled)
+  local reachedY = math.abs(diffY) < epsilon
+  local reachedX = not self.centeringRotX or math.abs(diffX) < epsilon
+
+  if reachedY and reachedX then
     camera.rotY = self.centerTargetRotY
-    self.centering = false
-    self.lastCenterRotY = nil
-
-    -- update base rotation state if we ended up with an offset
-    if self.centeringWithSteering then
-      self.baseRotY = camera.origRotY or 0
-      self.rotationFactor = self.centerSteeringOffset or 0
+    if self.centeringRotX and self.centerTargetRotX ~= nil then
+      camera.rotX = self.centerTargetRotX
     end
+    self:finalizeCentering(camera)
+    self:cancelCentering()
   else
-    -- ease-out interpolation: speed is proportional to distance
-    -- faster when far from center, slower when close to center
-    local smoothingFactor = self.centeringSmoothingFactor
-    local delta = diff * smoothingFactor * (dt / self.targetFrameTime)
-
-    camera.rotY = camera.rotY + delta
+    -- ease-out interpolation for Y axis
+    if not reachedY then
+      local deltaY = self:calculateSmoothDelta(diffY, centeringSmoothingFactor, dt)
+      camera.rotY = camera.rotY + deltaY
+    else
+      camera.rotY = self.centerTargetRotY
+    end
     self.lastCenterRotY = camera.rotY
+
+    -- ease-out interpolation for X axis
+    if self.centeringRotX and not reachedX then
+      local deltaX = self:calculateSmoothDelta(diffX, centeringSmoothingFactor, dt)
+      camera.rotX = camera.rotX + deltaX
+      self.lastCenterRotX = camera.rotX
+    elseif self.centeringRotX and self.centerTargetRotX ~= nil then
+      camera.rotX = self.centerTargetRotX
+      self.lastCenterRotX = camera.rotX
+    end
+  end
+end
+
+---Checks if player is manually looking backwards (more than 90 degrees from forward)
+-- Only checks manual camera rotation, excluding automatic steering follow
+function MouseSteeringCameraRotation:isLookingBackwards(camera)
+  if camera == nil or camera.origRotY == nil then
+    return false
+  end
+
+  local backwardsThreshold = math.pi / 2
+
+  local referenceRotY = self.baseRotY or camera.rotY
+  local diff = self:getAngleDiff(camera.origRotY, referenceRotY, camera)
+
+  return math.abs(diff) > backwardsThreshold
+end
+
+---Detects and applies user manual camera adjustments
+-- Returns the movement amount applied to baseRotY
+function MouseSteeringCameraRotation:applyUserMovement(camera)
+  if self.baseRotY == nil then
+    return 0
+  end
+
+  local epsilon = 0.001
+
+  local expectedRotY = self.baseRotY + self.rotationFactor
+  local userMovement = camera.rotY - expectedRotY
+
+  if math.abs(userMovement) > epsilon then
+    self.baseRotY = self.baseRotY + userMovement
+    return userMovement
+  end
+
+  return 0
+end
+
+---Initializes camera state for a new or restored camera
+function MouseSteeringCameraRotation:initializeCamera(camera, camIndex, cameraRotationDeadZoneDegrees, intensity)
+  self.lastCamIndex = camIndex
+  self.lastInsideCamera = camera
+
+  local steeringFactor = self:calculateSteeringFactor(cameraRotationDeadZoneDegrees)
+  local currentOffset = self:calculateSteeringOffset(steeringFactor, intensity)
+
+  local savedState = self:getSavedCameraState(camIndex)
+
+  if savedState ~= nil then
+    local origRotY = camera.origRotY or 0
+    -- rotYOffset is the manual offset (user's adjustment), not including steering
+    local manualOffset = savedState.rotYOffset
+
+    if savedState.preservePosition then
+      -- looking backwards - restore exact position, no steering follow
+      self.rotationFactor = 0
+      self.baseRotY = origRotY + manualOffset
+    elseif savedState.followSteering then
+      -- restore with steering follow from manual offset position
+      self.baseRotY = origRotY + manualOffset
+      self.rotationFactor = currentOffset
+    else
+      -- restore exact position without steering follow
+      self.rotationFactor = 0
+      self.baseRotY = origRotY + manualOffset
+    end
+
+    camera.rotY = self.baseRotY + self.rotationFactor
+  else
+    -- first time on this camera - start with steering follow active
+    -- camera immediately follows current wheel position
+    local origRotY = camera.origRotY or 0
+    self.rotationFactor = currentOffset
+    self.baseRotY = origRotY
+    camera.rotY = self.baseRotY + self.rotationFactor
   end
 end
 
 ---Updates camera rotation to follow wheel steering
--- @param dt number delta time in milliseconds
--- @param camera table active camera
--- @param camIndex number current camera index
--- @param intensity number rotation intensity setting
-function MouseSteeringCameraRotation:update(dt, camera, camIndex, intensity)
-  self:updateCentering(dt, camera, intensity)
+-- @param dt number Delta time in milliseconds
+-- @param camera table Active camera
+-- @param camIndex number Current camera index
+-- @param isPaused boolean Whether steering is paused (alt key held)
+function MouseSteeringCameraRotation:update(dt, camera, camIndex, isPaused)
+  -- get settings values
+  local intensity = self:getIntensity()
+  local deadzoneDegrees = self:getDeadzoneDegrees()
+  local centerVertical = self:getCenterVertical()
+
+  -- handle camera change
+  if self.lastCamIndex ~= nil and self.lastCamIndex ~= camIndex then
+    self:resetState(camIndex)
+  end
+
+  -- handle active state changes (toggle camera follow steering)
+  local wasActive = self.lastIsActive
+  local justActivated = self.isActive and not wasActive
+  local justDeactivated = not self.isActive and wasActive
+  self.lastIsActive = self.isActive
+
+  -- when activating, cancel any pending operations and start centering to steering follow
+  if justActivated then
+    if self.centering then
+      self:cancelCentering()
+    end
+    -- start centering to steering follow position
+    if camera ~= nil and self:isValidInsideCamera(camera) and intensity > 0 then
+      self:requestCenter(camera, intensity, deadzoneDegrees, centerVertical)
+    end
+  end
+
+  -- when deactivating, just freeze current position (no centering)
+  if justDeactivated then
+    if self.centering then
+      self:cancelCentering()
+    end
+    -- freeze current position
+    if self.baseRotY ~= nil and camera ~= nil then
+      camera.rotY = self.baseRotY + self.rotationFactor
+    end
+    self:resetState(camIndex)
+  end
+
+  -- if not active, do nothing
+  if not self.isActive then
+    return
+  end
+
+  -- from here on, isActive is true
+
+  -- handle pause state changes (alt key)
+  local pauseStarted = isPaused and not self.lastIsPaused
+  local pauseEnded = not isPaused and self.lastIsPaused
+  self.lastIsPaused = isPaused
+
+  -- when entering pause, cancel any automatic camera movement
+  if pauseStarted then
+    if self.centering then
+      self:cancelCentering()
+    end
+  end
+
+  -- when paused, do nothing - let game control camera
+  if isPaused then
+    return
+  end
+
+  -- when exiting pause, take current camera position as manual offset
+  -- camera will continue steering follow from this position
+  if pauseEnded then
+    if camera ~= nil and self:isValidInsideCamera(camera) then
+      local steeringFactor = self:calculateSteeringFactor(deadzoneDegrees)
+      local currentSteeringOffset = self:calculateSteeringOffset(steeringFactor, intensity)
+
+      -- set baseRotY so that baseRotY + currentSteeringOffset = camera.rotY
+      -- this means camera stays exactly where it is
+      self.baseRotY = camera.rotY - currentSteeringOffset
+      self.rotationFactor = currentSteeringOffset
+    end
+    return
+  end
+
+  -- process centering (for manual center requests)
+  self:updateCentering(dt, camera, intensity, deadzoneDegrees)
   if self.centering then
     return
   end
 
-  -- validate preconditions for rotation logic
-  if intensity <= 0 or camera == nil or not camera.isInside then
+  -- validate preconditions
+  if intensity <= 0 or not self:isValidInsideCamera(camera) then
     self:resetState(camIndex)
+    -- update saved camera states for outside camera
+    -- cameras not looking backwards will follow steering when returning
+    self:updateStatesForOutsideCamera()
     return
   end
 
-  local targetOffset = self:calculateSteeringFactor() * self.steerOffsetScale * intensity
-
-  -- initialize tracking state if needed
+  -- initialize if needed
   if self.lastCamIndex ~= camIndex or self.baseRotY == nil then
-    self.lastCamIndex = camIndex
-    self.lastInsideCamera = camera
-    self.baseRotY = camera.rotY
-    self.rotationFactor = targetOffset
+    self:initializeCamera(camera, camIndex, deadzoneDegrees, intensity)
+    return
+  end
+
+  -- handle backwards looking (disable follow but maintain position)
+  if self:isLookingBackwards(camera) then
+    self:applyUserMovement(camera)
     camera.rotY = self.baseRotY + self.rotationFactor
     return
   end
 
-  -- detect and apply user manual adjustments
-  local expectedRotY = self.baseRotY + self.rotationFactor
-  local userMovement = camera.rotY - expectedRotY
-  if math.abs(userMovement) > self.epsilon then
-    self.baseRotY = self.baseRotY + userMovement
-  end
+  -- camera rotation parameters
+  local rotationSmoothingFactor = 0.06
+  local rotationMaxDeltaPerMs = 0.002
+
+  -- normal steering follow update
+  local steeringFactor = self:calculateSteeringFactor(deadzoneDegrees)
+  local targetOffset = self:calculateSteeringOffset(steeringFactor, intensity)
+
+  -- apply user adjustments
+  self:applyUserMovement(camera)
 
   -- smooth transition to target offset
-  local maxDelta = self.rotationMaxDeltaPerMs * dt
   local diff = targetOffset - self.rotationFactor
-  self.rotationFactor = self.rotationFactor + math.clamp(diff, -maxDelta, maxDelta)
+  local delta = self:calculateSmoothDelta(diff, rotationSmoothingFactor, dt)
 
-  -- apply final rotation
+  -- clamp to max speed
+  local maxDelta = rotationMaxDeltaPerMs * dt
+  delta = math.clamp(delta, -maxDelta, maxDelta)
+
+  self.rotationFactor = self.rotationFactor + delta
   camera.rotY = self.baseRotY + self.rotationFactor
 end


### PR DESCRIPTION
New toggleable camera rotation that follows steering in cabin view with configurable intensity, dead zone, and vertical centering. Includes keybinds (Ctrl+, / Ctrl+Space) and full localization support.