### PR TITLE
fix: use shortest path for camera centering without CabView

### DIFF
--- a/src/misc/MouseSteeringCameraRotation.lua
+++ b/src/misc/MouseSteeringCameraRotation.lua
@@ -474,6 +474,12 @@ function MouseSteeringCameraRotation:updateCentering(dt, camera, intensity, came
     self.centerSteeringOffset = steeringOffset
   end
 
+  -- adjust target to shortest path if no CabView limits apply
+  local minRot, maxRot = self:getCabViewLimits(camera)
+  if minRot == nil or maxRot == nil then
+    self.centerTargetRotY = camera.rotY + self:normalizeAngleDiff(self.centerTargetRotY - camera.rotY)
+  end
+
   -- calculate differences
   local diffY
   if self.centerDirectDiff then


### PR DESCRIPTION
When the FS25_CabView mod is not active, the camera now takes the shortest rotational path to center instead of unwinding all previous rotations made by the player